### PR TITLE
fix: leftFlatMap to allow error handling (from left to right)

### DIFF
--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -40,7 +40,7 @@ export interface Task<E, R> {
   /**
    * Returns an Task with the error value mapped by the function f.
    */
-  leftFlatMap: <E2>(f: (_: E) => Task<never, E2>) => Task<E2, R>;
+  leftFlatMap: <E2, R2>(f: (_: E) => Task<E2, R2>) => Task<E2, R | R2>;
   /**
    * Returns an Task with the error value mapped by the function f, and the result value mapped by function g.
    */
@@ -284,14 +284,14 @@ class InternalTask<E, R> {
     >
   }
 
-  leftFlatMap<E2>(f: (_: E) => Task<never, E2>): Task<E2, R> {
-    return new InternalTask<E2, R>(
+  leftFlatMap<E2, R2>(f: (_: E) => Task<E2, R2>): Task<E2, R | R2> {
+    return new InternalTask<E2, R | R2>(
       undefined,
       this.operations.prepend({
         _tag: Ops.leftFlatMap,
         f
       })
-    ) as Task<E2, R>
+    ) as Task<E2, R | R2>
   }
 
   race<E, R>(f: Task<E, R>): Task<E, R> {

--- a/src/task/internal/runner.ts
+++ b/src/task/internal/runner.ts
@@ -87,15 +87,20 @@ export function runner(operations: Stack<Operation>) {
           if (isLeft) {
             switch (op._tag) {
               case Ops.leftMap: {
-                if (isLeft) {
-                  error = op.f(error)
-                }
+                error = op.f(error)
                 break
               }
               case Ops.leftFlatMap: {
-                x = op.f(error)
                 x = await op.f(error).runAsPromise()
-                error = x.value
+                if (x.tag === 'failue') {
+                  throw x.value
+                }
+                if (x.tag === 'error') {
+                  matchError(x.value)
+                } else {
+                  resetError()
+                  matchResult(x.value)
+                }
                 break
               }
               case Ops.orElse: {

--- a/src/task/test/arrowF.test.ts
+++ b/src/task/test/arrowF.test.ts
@@ -8,13 +8,6 @@ it('Task should flatMapF', async () => {
   expect(result).toEqual(3)
 })
 
-it('Task should flatMapF - dependency', async () => {
-  const result = await Task<never, number>(async () => right(1))
-    .flatMapF((a) => async () => right(a * 3))
-    .runAsPromiseResult()
-  expect(result).toEqual(3)
-})
-
 it('Task should flatMapF - fail', async () => {
   const { tag, value } = await Task<number, never>(async () => left(1))
     .flatMapF((a) => async () => right(a * 3))

--- a/src/task/test/task.test.ts
+++ b/src/task/test/task.test.ts
@@ -79,15 +79,23 @@ it('Task should leftMap', async () => {
   expect(value).toEqual(3)
 })
 
-it('Task should leftFlatMap', async () => {
+it('Task should leftFlatMap - to left', async () => {
   const { value, tag } = await Task<number, never>(async () => left(1))
-    .leftFlatMap((a) => resolve(a * 3))
+    .leftFlatMap((a) => reject(a * 3))
     .runAsPromise()
   expect(tag).toEqual('error')
   expect(value).toEqual(3)
 })
 
-it('Task should leftFlatMap - right', async () => {
+it('Task should leftFlatMap - to right', async () => {
+  const { value, tag } = await Task<number, never>(async () => left(1))
+    .leftFlatMap((a) => resolve(a * 3))
+    .runAsPromise()
+  expect(tag).toEqual('result')
+  expect(value).toEqual(3)
+})
+
+it('Task should leftFlatMap - from right (should not map)', async () => {
   const { tag, value } = await Task<never, number>(async () => right(1))
     .leftFlatMap((a) => resolve(a * 3))
     .runAsPromise()


### PR DESCRIPTION
Unsure if the original implementation of leftFlatMap was broken OR we have different expectations on how leftFlatMap should work, but essentially
- should allow proper error handling, meaning allowing transitioning from left to right in some cases

also: minor cleanup while I'm at it 